### PR TITLE
Redo largo_attachment_image_link_remove_filter to allow linking to non-images

### DIFF
--- a/wp-content/themes/freshenergy/functions.php
+++ b/wp-content/themes/freshenergy/functions.php
@@ -43,6 +43,7 @@ add_action( 'wp_enqueue_scripts', 'fe_styles', 20 );
  */
 function fe_thumbnail_size() {
 	set_post_thumbnail_size( 210, 140, true ); // thumbnail
+	add_image_size( 'thumbnail', 210, 140, true );
 }
 add_action( 'after_setup_theme', 'fe_thumbnail_size', 100 ); // needs to come after Largo's configuration at 10
 

--- a/wp-content/themes/freshenergy/functions.php
+++ b/wp-content/themes/freshenergy/functions.php
@@ -20,6 +20,7 @@ function largo_child_require_files() {
 	$includes = array(
 		'/homepages/layouts/freshenergy.php',
 		'/inc/widgets.php',
+		'/inc/images.php',
 	);
 	foreach ( $includes as $include ) {
 		require_once( get_stylesheet_directory() . $include );

--- a/wp-content/themes/freshenergy/inc/images.php
+++ b/wp-content/themes/freshenergy/inc/images.php
@@ -20,14 +20,13 @@ add_action( 'the_content', function( $content ) {
  * @since 0.1
  */
 function fe_attachment_image_link_remove_filter( $content ) {
-	$content =
-	preg_replace(
+	$content = preg_replace(
 		// replace nth item in first array with nth item in second array: saves middle
 		array(
 			'{<a(.*?)(?:wp-att|wp-content\/uploads)[^"\']+(?:png|jpeg|jpg|svg|gif)[^>]*><img}',
 			'{ wp-image-[0-9]*" /></a>}'
 		),
-		array('<img','" />'),
+		array( '<img', '" />' ),
 		$content
 	);
 	return $content;

--- a/wp-content/themes/freshenergy/inc/images.php
+++ b/wp-content/themes/freshenergy/inc/images.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Modifications of Largo's inc/images.php
+ */
+
+/**
+ * Remove Largo's action largo_attachment_image_link_remove_filter
+ * @since Largo 0.5.5.3
+ */
+add_action( 'the_content', function( $content ) {
+	remove_action( 'the_content', 'largo_attachment_image_link_remove_filter', 10 );
+	return $content;
+}, 5);
+
+/**
+ * Remove links to attachments
+ *
+ * @param object the post content
+ * @return object post content with image links stripped out
+ * @since 0.1
+ */
+function fe_attachment_image_link_remove_filter( $content ) {
+	$content =
+	preg_replace(
+		// replace nth item in first array with nth item in second array: saves middle
+		array(
+			'{<a(.*?)(?:wp-att|wp-content\/uploads)[^"\']+(?:png|jpeg|jpg|svg|gif)[^>]*><img}',
+			'{ wp-image-[0-9]*" /></a>}'
+		),
+		array('<img','" />'),
+		$content
+	);
+	return $content;
+}
+add_filter( 'the_content', 'fe_attachment_image_link_remove_filter' );
+


### PR DESCRIPTION
## Changes

- unregisters Largo's filter `largo_attachment_image_link_remove_filter( $the_content )` on the_content
- registers a FE-specific clone of that function that:
    - continues with previous behavior of stripping links around images in the post body, except
    - does not strip links if the link is to a URL that is not a WordPress-accepted image

## Testing

Test post on staging: https://freshenergy.staging.wpengine.com/image-testing-post/


Test content:
<details>

```
<section class="entry-content clearfix" itemprop="articleBody">
		
		<p style="text-align: center;"><a href="https://fresh-energy.org/wp-content/uploads/2017/02/2017-Sponsorship-Opportunities-1.pdf"><img class="alignnone size-full wp-image-35819" src="http://freshenergy.dev/wp-content/uploads/2017/05/button.fw_-e1486403826449.png" alt="Register Now" width="120" height="36"></a></p>
<p style="text-align: center;"><a href="http://freshenergy.dev/wp-content/uploads/2017/05/awesome.gif"><img class="aligncenter size-full wp-image-35822" src="http://freshenergy.dev/wp-content/uploads/2017/05/awesome.gif" alt="awesome" width="400" height="270"></a></p>
		
	</section>
```
and a url to test that opening regex against the content: http://www.regexr.com/
</details>

## Why

For https://app.asana.com/0/170602525751556/318691937184603

Because they wanted to link to an uploaded PDF using an image button.

